### PR TITLE
Add user in each host value

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -1,10 +1,11 @@
 <h3>Configuration</h3>
+<!--
 <h4>User</h4>
 <p>
-  Specify which user to login as during SSH.
+  Specify which default user for all host to login as during SSH.
 </p>
 <input type="text" class="span3" name="user" ng-model="config.user" placeholder="deploy">
-
+-->
 <h4>Hosts</h4>
 <p>
   Specify here which hosts to connect to during deployment.
@@ -18,8 +19,9 @@
   <li ng-hide="config.hosts.length">You must add at least one host in order to deploy!</li>
 </ul>
 <div class="form-inline">
-  <input placeholder="staging.example.com:22" ng-model="new_host" type="text">
+  <input placeholder="deployuser@staging.example.com:22" ng-model="new_host" type="text">
   <button class="btn btn-success" ng-disabled="!new_host" ng-click="addHost()">Add</button>
+  <p ng-show="error">Invalid host, host must be <b>'user@host:port'</b></p>
 </div>
 
 

--- a/config/config.js
+++ b/config/config.js
@@ -11,6 +11,7 @@ module.exports = ['$scope', function ($scope) {
     $scope.config = value;
   });
   $scope.saving = false;
+  $scope.error = false;
   $scope.save = function () {
     $scope.saving = true;
     $scope.pluginConfig('ssh_deploy', $scope.config, function() {
@@ -28,6 +29,9 @@ module.exports = ['$scope', function ($scope) {
       $scope.config.hosts.push(host.string);
       $scope.new_host = '';
       $scope.save();
+      $scope.error = false;
+    }else{
+      $scope.error = true;
     }
   };
 }];
@@ -36,13 +40,26 @@ module.exports = ['$scope', function ($scope) {
 module.exports = function (str) {
   var min = 1;
   var max = 65535;
-  var parts = str.split(':');
-  var host = parts[0];
+  var parts1 = str.split('@');
   var port = null;
-  if (parts.length > 2)
+  var user = null;
+  if (parts1.length != 2){
     return null;
-  if (parts[1]) {
-    port = parseInt(parts[1]);
+  }
+  var hostString = "";
+  if (parts1.length == 2){
+    user = parts1[0];
+    hostString = parts1[1];
+  } else {
+    hostString = parts1[0];
+  }
+  var parts2 = hostString.split(':');
+  if (parts2.length > 2){
+    return null;
+  }
+  var host = parts2[0];
+  if (parts2[1]) {
+    port = parseInt(parts2[1]);
     var validPort = port >= min && port <= max;
     if (!validPort) {
       return null;
@@ -51,7 +68,8 @@ module.exports = function (str) {
     port = 22;
   }
   return {
-    string: host+':'+port,
+    string: user+'@'+host+':'+port,
+    user: user,
     host: host,
     port: port
   }

--- a/deploy.js
+++ b/deploy.js
@@ -16,7 +16,7 @@ var getConnectionOptions = function(config, callback) {
         return {
           host: parsed.host,
           port: parsed.port,
-          username: config.user,
+          username: parsed.user,
           privateKey: key
         }
       }));

--- a/parse_host_string.js
+++ b/parse_host_string.js
@@ -1,13 +1,26 @@
 module.exports = function (str) {
   var min = 1;
   var max = 65535;
-  var parts = str.split(':');
-  var host = parts[0];
+  var parts1 = str.split('@');
   var port = null;
-  if (parts.length > 2)
+  var user = null;
+  if (parts1.length != 2){
     return null;
-  if (parts[1]) {
-    port = parseInt(parts[1]);
+  }
+  var hostString = "";
+  if (parts1.length == 2){
+    user = parts1[0];
+    hostString = parts1[1];
+  } else {
+    hostString = parts1[0];
+  }
+  var parts2 = hostString.split(':');
+  if (parts2.length > 2){
+    return null;
+  }
+  var host = parts2[0];
+  if (parts2[1]) {
+    port = parseInt(parts2[1]);
     var validPort = port >= min && port <= max;
     if (!validPort) {
       return null;
@@ -16,7 +29,8 @@ module.exports = function (str) {
     port = 22;
   }
   return {
-    string: host+':'+port,
+    string: user+'@'+host+':'+port,
+    user: user,
     host: host,
     port: port
   }

--- a/test/controller_test.js
+++ b/test/controller_test.js
@@ -25,12 +25,19 @@ describe("controller", function() {
       scope.new_host = str;
       scope.addHost();
     };
-
+    
     it("allows adding likely valid hosts", function() {
+      add('testUser@staging.example.org');
+      add('testUser@staging2.example.org:22');
+      add('testUser@staging3.example.org:2202');
+      expect(config.hosts).to.have.length(3);
+    });
+
+    it("won't add a host with missing user", function() {
       add('staging.example.org');
       add('staging2.example.org:22');
       add('staging3.example.org:2202');
-      expect(config.hosts).to.have.length(3);
+      expect(config.hosts).to.have.length(0);
     });
 
     it("won't add a host with more than one colon", function() {
@@ -46,8 +53,8 @@ describe("controller", function() {
     });
 
     it("converts implicit port to explicit port when adding", function() {
-      add('staging.example.org');
-      expect(config.hosts[0]).to.eq('staging.example.org:22');
+      add('testUser@staging.example.org');
+      expect(config.hosts[0]).to.eq('testUser@staging.example.org:22');
     });
   });
 });

--- a/test/deploy_test.js
+++ b/test/deploy_test.js
@@ -26,10 +26,10 @@ describe("deploy", function() {
     describe("when three hosts configured", function() {
       beforeEach(function() {
         config = { hosts: [
-          'example.org',
-          'example2.org:2022',
-          '127.0.0.1:22'
-        ], user: "testUser", script: "./deploy.sh <%= ref.branch %>"};
+          'testUser@example.org',
+          'testUser@example2.org:2022',
+          'testUser@127.0.0.1:22'
+        ], script: "./deploy.sh <%= ref.branch %>"};
         context = {
           comment:sinon.stub(),
           job: { project: { name: "foo", branches: [] }, ref: { branch: 'master' } }


### PR DESCRIPTION
Current strider-ssh-deploy can't deploy to mutil servers which are different username.
I've fixed it with some change.
- Host value will be same as **deployuser@staging.example.com:22** instead of **staging.example.com:22**
- Remove 'config.user', so people who update with these commits must be add user to host value before deploy.