### PR TITLE
downgrade yarn to 1.12.x; fix bundler syntax for node 4

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var { spawn } = require('child_process');
+var spawn = require('child_process').spawn;
 
 module.exports = {
   // This is how you would bundle a NODE.JS project...
@@ -9,7 +9,10 @@ module.exports = {
   // See https://github.com/Strider-CD/strider-ssh-deploy/issues/2
   bundleProject: function (dataDir, name, progress, done) {
     var bundlePath = `/tmp/${name}.tar.gz`;
-    spawn('yarn', ['pack', '--filename', bundlePath], { stdio: 'ignore' }).on('close', function (code) {
+    spawn(
+      './node_modules/.bin/yarn', ['pack', '--filename', bundlePath],
+      { stdio: ['ignore', 'ignore', process.stderr] }
+    ).on('close', function (code) {
       if (code !== 0) {
         done(new Error('Failed to create project bundle'));
       } else {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.13.1",
     "progress-stream": "^1.2.0",
     "ssh2": "^0.5.0",
-    "yarn": "^1.19.1"
+    "yarn": "~1.12.3"
   },
   "strider": {
     "type": "job",


### PR DESCRIPTION
If you want to support node 4 again. Otherwise, just skip it.